### PR TITLE
Added LifeSpan and RenewalTimeSpan properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,4 @@ _Pvt_Extensions
 .fake/
 /PKI.Test
 *.DotSettings
+/.editorconfig

--- a/PKI.sln
+++ b/PKI.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29920.165
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32210.238
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PKI", "PKI\PKI.csproj", "{5AD7D76A-09A4-4E4F-AFA7-7798E0E9CD89}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PKI.Test", "PKI.Test\PKI.Test.csproj", "{359ED8C6-47B5-4321-9B60-62E0F53A5384}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D26851EC-3DF7-44A6-9B19-CBA558D3E019}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/PKI/CertificateTemplates/CertificateTemplateSettings.cs
+++ b/PKI/CertificateTemplates/CertificateTemplateSettings.cs
@@ -234,7 +234,7 @@ namespace PKI.CertificateTemplates {
                 Array.Reverse(rawData);
                 StringBuilder SB = new StringBuilder();
                 foreach (Byte item in rawData) { SB.Append($"{item:X2}"); }
-                hours = (long)(Convert.ToInt64(SB.ToString(), 16) * -.0000001 / 3600);
+                hours = (Int64)(Convert.ToInt64(SB.ToString(), 16) * -.0000001 / 3600);
             } else {
                 hours = fileTime / 3600;
             }
@@ -261,9 +261,9 @@ namespace PKI.CertificateTemplates {
         }
         void readEKU() {
             try {
-                object[] EkuObject = (object[])_entry[DsUtils.PropCertTemplateEKU];
+                Object[] EkuObject = (Object[])_entry[DsUtils.PropCertTemplateEKU];
                 if (EkuObject != null) {
-                    foreach (object item in EkuObject) {
+                    foreach (Object item in EkuObject) {
                         _ekuList.Add(new Oid(item.ToString()));
                     }
                 }
@@ -274,9 +274,9 @@ namespace PKI.CertificateTemplates {
         }
         void readCertPolicies() {
             try {
-                object[] oids = (object[])_entry[DsUtils.PropPkiCertPolicy];
+                Object[] oids = (Object[])_entry[DsUtils.PropPkiCertPolicy];
                 if (oids == null) { return; }
-                foreach (object oid in oids) {
+                foreach (Object oid in oids) {
                     _certPolicies.Add(new Oid((String)oid));
                 }
             } catch {
@@ -285,9 +285,9 @@ namespace PKI.CertificateTemplates {
         }
         void readCriticalExtensions() {
             try {
-                object[] oids = (object[])_entry[DsUtils.PropPkiCriticalExt];
+                Object[] oids = (Object[])_entry[DsUtils.PropPkiCriticalExt];
                 if (oids == null) { return; }
-                foreach (object oid in oids) {
+                foreach (Object oid in oids) {
                     _criticalExtensions.Add(new Oid((String)oid));
                 }
             } catch {
@@ -297,7 +297,7 @@ namespace PKI.CertificateTemplates {
         void readSuperseded() {
             List<String> temps = new List<String>();
             try {
-                object[] templates = (object[])_entry[DsUtils.PropPkiSupersede];
+                Object[] templates = (Object[])_entry[DsUtils.PropPkiSupersede];
                 if (templates != null) {
                     temps.AddRange(templates.Cast<String>());
                 }

--- a/PKI/PKI.csproj
+++ b/PKI/PKI.csproj
@@ -432,7 +432,11 @@
     <Content Include="_ExternalReferences\SysadminsLV.Asn1Parser.dll" />
     <Content Include="_ExternalReferences\SysadminsLV.Asn1Parser.XML" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="..\.editorconfig">
+      <Link>.editorconfig</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
@Crypt32 I know we eventually want to be able to report on certificates that are "approaching expiry". I think that is relative based on the lifespan dictated by the template. For instance, 3 days from expiry for a 1-year template is different from 3 days from expiry for a short-lived cert type such as CAExchange