### PR TITLE
Implemented Certificate template factory

### DIFF
--- a/src/SysadminsLV.PKI.Win/CertificateServices/CATemplate.cs
+++ b/src/SysadminsLV.PKI.Win/CertificateServices/CATemplate.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using PKI.CertificateTemplates;
+using SysadminsLV.PKI.CertificateTemplates;
 using SysadminsLV.PKI.Dcom;
 using SysadminsLV.PKI.Dcom.Implementations;
 using SysadminsLV.PKI.Exceptions;
@@ -74,7 +75,7 @@ public class CATemplate {
 
         String[,] templates = propReader.GetCaTemplates();
         for (Int32 i = 0; i <= templates.GetUpperBound(0); i++) {
-            _templates.Add(CertificateTemplate.FromCommonName(templates[i, 0]));
+            _templates.Add(CertificateTemplateFactory.CreateFromCommonNameDs(templates[i, 0]));
         }
     }
     Boolean IsSupported(Int32 schemaVersion) {

--- a/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplate.cs
@@ -192,9 +192,9 @@ public class CertificateTemplate {
     /// Enumerates certificate templates registered in Active Directory.
     /// </summary>
     /// <returns>An array of certificate templates.</returns>
-    [Obsolete("Use 'CertificateTemplateFactory.GetTemplatesDs()' instead.")]
+    [Obsolete("Use 'CertificateTemplateFactory.GetTemplatesFromDs()' instead.")]
     public static CertificateTemplate[] EnumTemplates() {
-        return CertificateTemplateFactory.GetTemplatesDs().ToArray();
+        return CertificateTemplateFactory.GetTemplatesFromDs().ToArray();
     }
 
     /// <summary>

--- a/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplate.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using SysadminsLV.PKI.CertificateTemplates;
-using SysadminsLV.PKI.Management.ActiveDirectory;
 using SysadminsLV.PKI.Security.AccessControl;
 
 namespace PKI.CertificateTemplates;
@@ -193,12 +192,9 @@ public class CertificateTemplate {
     /// Enumerates certificate templates registered in Active Directory.
     /// </summary>
     /// <returns>An array of certificate templates.</returns>
+    [Obsolete("Use 'CertificateTemplateFactory.GetTemplatesDs()' instead.")]
     public static CertificateTemplate[] EnumTemplates() {
-        var retValue = new List<CertificateTemplate>();
-        foreach (IAdcsCertificateTemplate templateInfo in DsCertificateTemplate.GetAll()) {
-            retValue.Add(CertificateTemplateFactory.CreateFromTemplateInfo(templateInfo));
-        }
-        return retValue.ToArray();
+        return CertificateTemplateFactory.GetTemplatesDs().ToArray();
     }
 
     /// <summary>

--- a/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplate.cs
@@ -195,8 +195,8 @@ public class CertificateTemplate {
     /// <returns>An array of certificate templates.</returns>
     public static CertificateTemplate[] EnumTemplates() {
         var retValue = new List<CertificateTemplate>();
-        foreach (IAdcsCertificateTemplate dsEntry in DsCertificateTemplate.GetAll()) {
-            retValue.Add(new CertificateTemplate(dsEntry));
+        foreach (IAdcsCertificateTemplate templateInfo in DsCertificateTemplate.GetAll()) {
+            retValue.Add(CertificateTemplateFactory.CreateFromTemplateInfo(templateInfo));
         }
         return retValue.ToArray();
     }
@@ -308,24 +308,27 @@ public class CertificateTemplate {
     /// </summary>
     /// <param name="cn">Certificate template's common name.</param>
     /// <returns>Certificate template object.</returns>
+    [Obsolete("Use 'CertificateTemplateFactory.CreateFromCommonNameDs' instead.")]
     public static CertificateTemplate FromCommonName(String cn) {
-        return new CertificateTemplate(DsCertificateTemplate.FromCommonName(cn));
+        return CertificateTemplateFactory.CreateFromCommonNameDs(cn);
     }
     /// <summary>
     /// Creates a new instance of <strong>CertificateTemplate</strong> object from certificate template's display name.
     /// </summary>
     /// <param name="displayName">Certificate template's display/friendly name.</param>
     /// <returns>Certificate template object.</returns>
+    [Obsolete("Use 'CertificateTemplateFactory.CreateFromDisplayNameDs' instead.")]
     public static CertificateTemplate FromDisplayName(String displayName) {
-        return new CertificateTemplate(DsCertificateTemplate.FromDisplayName(displayName));
+        return CertificateTemplateFactory.CreateFromDisplayNameDs(displayName);
     }
     /// <summary>
     /// Creates a new instance of <strong>CertificateTemplate</strong> object from certificate template's object identifier (OID).
     /// </summary>
     /// <param name="oid">Certificate template's dot-decimal object identifier.</param>
     /// <returns>Certificate template object.</returns>
+    [Obsolete("Use 'CertificateTemplateFactory.CreateFromOidDs' instead.")]
     public static CertificateTemplate FromOid(String oid) {
-        return new CertificateTemplate(DsCertificateTemplate.FromOid(oid));
+        return CertificateTemplateFactory.CreateFromOidDs(oid);
     }
 
 }

--- a/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplate.cs
@@ -239,6 +239,7 @@ public class CertificateTemplate {
     /// Gets access control list (security descriptor) of the current certificate template.
     /// </summary>
     /// <returns>Security descriptor.</returns>
+    /// <exception cref="ArgumentException">Certificate template doesn't exist in Active Directory or connection failed.</exception>
     public CertTemplateSecurityDescriptor GetSecurityDescriptor() {
         return new CertTemplateSecurityDescriptor(this);
     }

--- a/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplateFactory.cs
+++ b/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplateFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Interop.CERTENROLLLib;
 using PKI.CertificateTemplates;
@@ -64,5 +65,13 @@ public static class CertificateTemplateFactory {
     /// <exception cref="COMException">Any exception propagated from COM object.</exception>
     public static CertificateTemplate CreateFromCertEnrollTemplate(IX509CertificateTemplate template) {
         return new CertificateTemplate(new CertEnrollCertificateTemplate(template));
+    }
+
+    /// <summary>
+    /// Creates a collection of all certificate templates registered in Active Directory.
+    /// </summary>
+    /// <returns>Certificate template collection.</returns>
+    public static CertificateTemplateCollection GetTemplatesDs() {
+        return new CertificateTemplateCollection(DsCertificateTemplate.GetAll().Select(CreateFromTemplateInfo));
     }
 }

--- a/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplateFactory.cs
+++ b/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplateFactory.cs
@@ -71,7 +71,15 @@ public static class CertificateTemplateFactory {
     /// Creates a collection of all certificate templates registered in Active Directory.
     /// </summary>
     /// <returns>Certificate template collection.</returns>
-    public static CertificateTemplateCollection GetTemplatesDs() {
+    public static CertificateTemplateCollection GetTemplatesFromDs() {
         return new CertificateTemplateCollection(DsCertificateTemplate.GetAll().Select(CreateFromTemplateInfo));
+    }
+    /// <summary>
+    /// Creates a collection of all certificate templates registered in local registry cache.
+    /// </summary>
+    /// <returns>Certificate template collection.</returns>
+    /// <exception cref="ArgumentException">Registry cache doesn't exist.</exception>
+    public static CertificateTemplateCollection GetTemplatesFromRegistry() {
+        return new CertificateTemplateCollection(RegCertificateTemplate.GetAll().Select(CreateFromTemplateInfo));
     }
 }

--- a/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplateFactory.cs
+++ b/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplateFactory.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Interop.CERTENROLLLib;
+using PKI.CertificateTemplates;
+using SysadminsLV.PKI.Dcom.Implementations;
+using SysadminsLV.PKI.Management.ActiveDirectory;
+using SysadminsLV.PKI.Management.CertificateServices;
+
+namespace SysadminsLV.PKI.CertificateTemplates;
+
+/// <summary>
+/// Represents unified factory for <see cref="CertificateTemplate"/> class.
+/// </summary>
+public static class CertificateTemplateFactory {
+    /// <summary>
+    /// Creates an instance of <see cref="CertificateTemplate"/> from <see cref="IAdcsCertificateTemplate"/> interface implementation.
+    /// </summary>
+    /// <param name="templateInfo">Template information.</param>
+    /// <returns>Certificate template.</returns>
+    public static CertificateTemplate CreateFromTemplateInfo(IAdcsCertificateTemplate templateInfo) {
+        return new CertificateTemplate(templateInfo);
+    }
+    /// <summary>
+    /// Creates an instance of <see cref="CertificateTemplate"/> from template common name using local registry cache.
+    /// </summary>
+    /// <param name="commonName">Template common name.</param>
+    /// <returns>Certificate template.</returns>
+    /// <exception cref="ArgumentException">Requested template was not found.</exception>
+    public static CertificateTemplate CreateFromCommonNameRegistry(String commonName) {
+        return new CertificateTemplate(new RegCertificateTemplate(commonName));
+    }
+    /// <summary>
+    /// Creates an instance of <see cref="CertificateTemplate"/> from template common name using Active Directory storage.
+    /// </summary>
+    /// <param name="commonName">Template common name.</param>
+    /// <returns>Certificate template.</returns>
+    /// <exception cref="ArgumentException">Requested template was not found.</exception>
+    public static CertificateTemplate CreateFromCommonNameDs(String commonName) {
+        return new CertificateTemplate(DsCertificateTemplate.FromCommonName(commonName));
+    }
+    /// <summary>
+    /// Creates an instance of <see cref="CertificateTemplate"/> from template display name using Active Directory storage.
+    /// </summary>
+    /// <param name="displayName">Template display name.</param>
+    /// <returns>Certificate template.</returns>
+    /// <exception cref="ArgumentException">Requested template was not found.</exception>
+    public static CertificateTemplate CreateFromDisplayNameDs(String displayName) {
+        return new CertificateTemplate(DsCertificateTemplate.FromDisplayName(displayName));
+    }
+    /// <summary>
+    /// Creates an instance of <see cref="CertificateTemplate"/> from template OID value using Active Directory storage.
+    /// </summary>
+    /// <param name="oid">Template OID string in dot-decimal notation.</param>
+    /// <returns>Certificate template.</returns>
+    /// <exception cref="ArgumentException">Requested template was not found.</exception>
+    public static CertificateTemplate CreateFromOidDs(String oid) {
+        return new CertificateTemplate(DsCertificateTemplate.FromOid(oid));
+    }
+    /// <summary>
+    /// Creates an instance of <see cref="CertificateTemplate"/> from <see cref="IX509CertificateTemplate"/> COM interface.
+    /// </summary>
+    /// <param name="template">COM template object.</param>
+    /// <returns>Certificate template.</returns>
+    /// <exception cref="COMException">Any exception propagated from COM object.</exception>
+    public static CertificateTemplate CreateFromCertEnrollTemplate(IX509CertificateTemplate template) {
+        return new CertificateTemplate(new CertEnrollCertificateTemplate(template));
+    }
+}

--- a/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplateXcepFormatter.cs
+++ b/src/SysadminsLV.PKI.Win/CertificateTemplates/CertificateTemplateXcepFormatter.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using Interop.CERTENROLLLib;
 using PKI.CertificateTemplates;
 using SysadminsLV.PKI.Cryptography;
-using SysadminsLV.PKI.Dcom.Implementations;
 using SysadminsLV.PKI.Utils;
 
 namespace SysadminsLV.PKI.CertificateTemplates;
@@ -282,7 +281,7 @@ class CertificateTemplateXCepFormatter : ICertificateTemplateFormatter {
         try {
             policy.InitializeImport(Encoding.UTF8.GetBytes(serializedString));
             foreach (IX509CertificateTemplate comTemplate in policy.GetTemplates()) {
-                retValue.Add(new CertificateTemplate(new CertEnrollCertificateTemplate(comTemplate)));
+                retValue.Add(CertificateTemplateFactory.CreateFromCertEnrollTemplate(comTemplate));
                 CryptographyUtils.ReleaseCom(comTemplate);
             }
         } catch (Exception ex) {

--- a/src/SysadminsLV.PKI.Win/Dcom/Implementations/CertEnrollCertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/Dcom/Implementations/CertEnrollCertificateTemplate.cs
@@ -16,7 +16,7 @@ namespace SysadminsLV.PKI.Dcom.Implementations;
 /// <summary>
 /// Represents CertEnroll-based implementation of <see cref="IAdcsCertificateTemplate"/>.
 /// </summary>
-public class CertEnrollCertificateTemplate : IAdcsCertificateTemplate {
+public sealed class CertEnrollCertificateTemplate : IAdcsCertificateTemplate {
     readonly List<Byte> _validityPeriod = [];
     readonly List<Byte> _renewalPeriod = [];
     readonly List<String> _raAppPolicies = [];
@@ -34,7 +34,7 @@ public class CertEnrollCertificateTemplate : IAdcsCertificateTemplate {
     /// <exception cref="ArgumentNullException">
     ///     <strong>template</strong> parameter is null.
     /// </exception>
-    public CertEnrollCertificateTemplate(IX509CertificateTemplate template) {
+    internal CertEnrollCertificateTemplate(IX509CertificateTemplate template) {
         if (template == null) {
             throw new ArgumentNullException(nameof(template));
         }

--- a/src/SysadminsLV.PKI.Win/Enrollment/Policy/PolicyServerClient.cs
+++ b/src/SysadminsLV.PKI.Win/Enrollment/Policy/PolicyServerClient.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using Interop.CERTENROLLLib;
 using PKI.CertificateTemplates;
-using SysadminsLV.PKI.Dcom.Implementations;
+using SysadminsLV.PKI.CertificateTemplates;
 using SysadminsLV.PKI.Exceptions;
 using SysadminsLV.PKI.Utils;
 
@@ -167,7 +167,7 @@ public class PolicyServerClient {
     void get_templates() {
         Templates = policy.GetTemplates()
             .Cast<IX509CertificateTemplate>()
-            .Select(x => new CertificateTemplate(new CertEnrollCertificateTemplate(x)))
+            .Select(CertificateTemplateFactory.CreateFromCertEnrollTemplate)
             .ToArray();
     }
     void set_property(String propName, Object propValue) {

--- a/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertTemplateContainer.cs
+++ b/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertTemplateContainer.cs
@@ -1,23 +1,23 @@
 ﻿using System;
-using PKI.CertificateTemplates;
+using SysadminsLV.PKI.CertificateTemplates;
 
-namespace SysadminsLV.PKI.Management.ActiveDirectory {
-    /// <summary>
-    /// Represents a certificate template container in Active Directory.
-    /// </summary>
-    public class DsCertTemplateContainer : DsPkiContainer {
+namespace SysadminsLV.PKI.Management.ActiveDirectory;
+/// <summary>
+/// Represents a certificate template container in Active Directory.
+/// </summary>
+public class DsCertTemplateContainer : DsPkiContainer {
 
-        internal DsCertTemplateContainer() {
-            ContainerType = DsContainerType.CertificateTemplates;
-            BaseEntryPath = "CN=Certificate Templates";
-        }
-
-        /// <summary>
-        /// Gets an array of registered in Active Directory certificate templates.
-        /// </summary>
-        public CertificateTemplate[] CertificateTemplates => CertificateTemplate.EnumTemplates();
-
-        /// <inheritdoc />
-        public override void SaveChanges(Boolean forceDelete) { }
+    internal DsCertTemplateContainer() {
+        ContainerType = DsContainerType.CertificateTemplates;
+        BaseEntryPath = "CN=Certificate Templates";
+        CertificateTemplates = CertificateTemplateFactory.GetTemplatesDs();
     }
+
+    /// <summary>
+    /// Gets an array of registered in Active Directory certificate templates.
+    /// </summary>
+    public CertificateTemplateCollection CertificateTemplates { get; }
+
+    /// <inheritdoc />
+    public override void SaveChanges(Boolean forceDelete) { }
 }

--- a/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertTemplateContainer.cs
+++ b/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertTemplateContainer.cs
@@ -10,7 +10,7 @@ public class DsCertTemplateContainer : DsPkiContainer {
     internal DsCertTemplateContainer() {
         ContainerType = DsContainerType.CertificateTemplates;
         BaseEntryPath = "CN=Certificate Templates";
-        CertificateTemplates = CertificateTemplateFactory.GetTemplatesDs();
+        CertificateTemplates = CertificateTemplateFactory.GetTemplatesFromDs();
     }
 
     /// <summary>

--- a/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertificateTemplate.cs
@@ -276,7 +276,7 @@ public sealed class DsCertificateTemplate : IAdcsCertificateTemplate {
     /// Returns a collection of certificate templates as <see cref="IAdcsCertificateTemplate"/> instances.
     /// </summary>
     /// <returns>A collection of certificate templates.</returns>
-    public static IEnumerable<IAdcsCertificateTemplate> GetAll() {
+    internal static IEnumerable<IAdcsCertificateTemplate> GetAll() {
         if (!DsUtils.Ping()) {
             throw new Exception(ErrorHelper.E_DCUNAVAILABLE);
         }

--- a/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertificateTemplate.cs
@@ -248,6 +248,14 @@ public sealed class DsCertificateTemplate : IAdcsCertificateTemplate {
     }
 
     /// <summary>
+    /// Gets LDAP path for specified certificate template.
+    /// </summary>
+    /// <param name="commonName">Template common name.</param>
+    /// <returns>LDAP path. Can be null if template with specified name doesn't exist.</returns>
+    internal static String GetLdapPath(String commonName) {
+        return DsUtils.Find(_baseDsPath, DsUtils.PropCN, commonName);
+    }
+    /// <summary>
     /// Returns an instance of <see cref="IAdcsCertificateTemplate"/> interface from template common name.
     /// </summary>
     /// <param name="cn">Template common name.</param>

--- a/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/Management/ActiveDirectory/DsCertificateTemplate.cs
@@ -15,7 +15,7 @@ namespace SysadminsLV.PKI.Management.ActiveDirectory;
 /// <summary>
 /// Represents an Active Directory-based implementation of <see cref="IAdcsCertificateTemplate"/> interface.
 /// </summary>
-public class DsCertificateTemplate : IAdcsCertificateTemplate {
+public sealed class DsCertificateTemplate : IAdcsCertificateTemplate {
     static readonly String _baseDsPath = $"CN=Certificate Templates, CN=Public Key Services, CN=Services,{DsUtils.ConfigContext}";
     readonly List<Byte> _validityPeriod = [];
     readonly List<Byte> _renewalPeriod = [];
@@ -252,7 +252,7 @@ public class DsCertificateTemplate : IAdcsCertificateTemplate {
     /// </summary>
     /// <param name="cn">Template common name.</param>
     /// <returns>Instance of <see cref="IAdcsCertificateTemplate"/> interface.</returns>
-    public static IAdcsCertificateTemplate FromCommonName(String cn) {
+    internal static IAdcsCertificateTemplate FromCommonName(String cn) {
         return new DsCertificateTemplate("Name", cn);
     }
     /// <summary>
@@ -260,7 +260,7 @@ public class DsCertificateTemplate : IAdcsCertificateTemplate {
     /// </summary>
     /// <param name="displayName">Certificate template's display/friendly name.</param>
     /// <returns>Certificate template object.</returns>
-    public static IAdcsCertificateTemplate FromDisplayName(String displayName) {
+    internal static IAdcsCertificateTemplate FromDisplayName(String displayName) {
         return new DsCertificateTemplate("DisplayName", displayName);
     }
     /// <summary>
@@ -268,7 +268,7 @@ public class DsCertificateTemplate : IAdcsCertificateTemplate {
     /// </summary>
     /// <param name="oid">Certificate template's dot-decimal object identifier.</param>
     /// <returns>Certificate template object.</returns>
-    public static IAdcsCertificateTemplate FromOid(String oid) {
+    internal static IAdcsCertificateTemplate FromOid(String oid) {
         return new DsCertificateTemplate("OID", oid);
     }
 

--- a/src/SysadminsLV.PKI.Win/Management/CertificateServices/RegCertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/Management/CertificateServices/RegCertificateTemplate.cs
@@ -14,7 +14,7 @@ namespace SysadminsLV.PKI.Management.CertificateServices;
 /// <summary>
 /// Represents local registry cache-based implementation of <see cref="IAdcsCertificateTemplate"/> interface.
 /// </summary>
-public class RegCertificateTemplate : IAdcsCertificateTemplate {
+public sealed class RegCertificateTemplate : IAdcsCertificateTemplate {
     readonly List<Byte> _validityPeriod = [];
     readonly List<Byte> _renewalPeriod = [];
     readonly List<String> _raAppPolicies = [];
@@ -30,7 +30,7 @@ public class RegCertificateTemplate : IAdcsCertificateTemplate {
     /// </summary>
     /// <param name="commonName">Template common name.</param>
     /// <exception cref="ArgumentException"></exception>
-    public RegCertificateTemplate(String commonName) {
+    internal RegCertificateTemplate(String commonName) {
         var regReader = new RegistryReader(@"SOFTWARE\Microsoft\Cryptography\CertificateTemplateCache");
         if (!regReader.TestSubKeyExists(commonName)) {
             throw new ArgumentException($"Specified template '{commonName}' does not exist in local template cache.");

--- a/src/SysadminsLV.PKI.Win/Management/CertificateServices/RegCertificateTemplate.cs
+++ b/src/SysadminsLV.PKI.Win/Management/CertificateServices/RegCertificateTemplate.cs
@@ -169,4 +169,15 @@ public sealed class RegCertificateTemplate : IAdcsCertificateTemplate {
             _raAppPolicies.AddRange(raAppPolicies);
         }
     }
+
+    internal static IEnumerable<IAdcsCertificateTemplate> GetAll() {
+        var regReader = new RegistryReader(@"SOFTWARE\Microsoft\Cryptography");
+        if (!regReader.TestSubKeyExists("CertificateTemplateCache")) {
+            throw new ArgumentException("Certificate template registry storage doesn't exist.");
+        }
+        regReader.SetContextSubKey("CertificateTemplateCache");
+        foreach (String templateName in regReader.GetSubKeyNames()) {
+            yield return new RegCertificateTemplate(templateName);
+        }
+    }
 }

--- a/src/SysadminsLV.PKI.Win/Security/AccessControl/CertTemplateSecurityDescriptor.cs
+++ b/src/SysadminsLV.PKI.Win/Security/AccessControl/CertTemplateSecurityDescriptor.cs
@@ -22,16 +22,16 @@ public sealed class CertTemplateSecurityDescriptor : CommonObjectSecurity {
     internal CertTemplateSecurityDescriptor(CertificateTemplate template) : base(false) {
         DisplayName = template.DisplayName;
         _schemaVersion = template.SchemaVersion;
-        String ldapPath;
         if (String.IsNullOrEmpty(template.DistinguishedName)) {
-            ldapPath = DsCertificateTemplate.GetLdapPath(template.Name);
+            String ldapPath = DsCertificateTemplate.GetLdapPath(template.Name);
             if (String.IsNullOrEmpty(ldapPath)) {
                 throw new ArgumentException($"Requested certificate template '{template.Name}' was not found in Active Directory or connection failed.");
             }
+            _x500Path = ldapPath;
         } else {
-            ldapPath = template.DistinguishedName;
+            _x500Path = "LDAP://" + template.DistinguishedName;
         }
-        _x500Path = "LDAP://" + ldapPath;
+
         fromActiveDirectorySecurity();
     }
 

--- a/src/SysadminsLV.PKI.Win/SysadminsLV.PKI.Win.csproj
+++ b/src/SysadminsLV.PKI.Win/SysadminsLV.PKI.Win.csproj
@@ -112,6 +112,7 @@
   <ItemGroup>
     <Compile Include="CertificateTemplates\CertificateTemplateCollection.cs" />
     <Compile Include="CertificateTemplates\CertificateTemplateExportFormat.cs" />
+    <Compile Include="CertificateTemplates\CertificateTemplateFactory.cs" />
     <Compile Include="CertificateTemplates\CertificateTemplateXcepFormatter.cs" />
     <Compile Include="CertificateTemplates\ICertificateTemplateCertificatePolicy.cs" />
     <Compile Include="CertificateTemplates\IAdcsCertificateTemplate.cs" />

--- a/tests/SysadminsLV.PKI.Win.Tests/CertificateTemplates/CertificateTemplateTests.cs
+++ b/tests/SysadminsLV.PKI.Win.Tests/CertificateTemplates/CertificateTemplateTests.cs
@@ -7,9 +7,6 @@ using Interop.CERTENROLLLib;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PKI.CertificateTemplates;
 using SysadminsLV.PKI.CertificateTemplates;
-using SysadminsLV.PKI.Dcom.Implementations;
-using SysadminsLV.PKI.Management.ActiveDirectory;
-using SysadminsLV.PKI.Management.CertificateServices;
 using SysadminsLV.PKI.Utils;
 
 namespace SysadminsLV.PKI.Win.Tests.CertificateTemplates;
@@ -19,8 +16,7 @@ public class CertificateTemplateTests {
     public void TestRegTemplates() {
         foreach (CertificateTemplate template in CertificateTemplate.EnumTemplates()) {
             Console.WriteLine(template.Name);
-            var regTemplate = new RegCertificateTemplate(template.Name);
-            var refTemplate = new CertificateTemplate(regTemplate);
+            CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameRegistry(template.Name);
             assertTemplate(template, refTemplate);
         }
     }
@@ -28,8 +24,7 @@ public class CertificateTemplateTests {
     public void TestDsTemplates() {
         foreach (CertificateTemplate template in CertificateTemplate.EnumTemplates()) {
             Console.WriteLine(template.Name);
-            IAdcsCertificateTemplate dsTemplate = DsCertificateTemplate.FromCommonName(template.Name);
-            var refTemplate = new CertificateTemplate(dsTemplate);
+            CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameDs(template.Name);
             assertTemplate(template, refTemplate);
         }
     }
@@ -44,8 +39,7 @@ public class CertificateTemplateTests {
         for (Int32 index = 0; index < col.Count; index++) {
             CertificateTemplate source = col[index];
             Console.WriteLine(source.Name);
-            var certEnrollTemplate = new CertEnrollCertificateTemplate(templates[index]);
-            var refTemplate = new CertificateTemplate(certEnrollTemplate);
+            CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCertEnrollTemplate(templates[index]);
             assertTemplate(source, refTemplate);
         }
 
@@ -138,8 +132,7 @@ public class CertificateTemplateTests {
         var col = new CertificateTemplateCollection();
         foreach (CertificateTemplate template in CertificateTemplate.EnumTemplates()) {
             Console.WriteLine(template.Name);
-            var regTemplate = new RegCertificateTemplate(template.Name);
-            var refTemplate = new CertificateTemplate(regTemplate);
+            CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameRegistry(template.Name);
             col.Add(refTemplate);
         }
         String serializedString = col.Export(CertificateTemplateExportFormat.XCep);
@@ -159,8 +152,7 @@ public class CertificateTemplateTests {
         var col = new CertificateTemplateCollection();
         foreach (CertificateTemplate template in CertificateTemplate.EnumTemplates()) {
             Console.WriteLine(template.Name);
-            IAdcsCertificateTemplate dsTemplate = DsCertificateTemplate.FromCommonName(template.Name);
-            var refTemplate = new CertificateTemplate(dsTemplate);
+            CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameDs(template.Name);
             col.Add(refTemplate);
         }
         String serializedString = col.Export(CertificateTemplateExportFormat.XCep);

--- a/tests/SysadminsLV.PKI.Win.Tests/CertificateTemplates/CertificateTemplateTests.cs
+++ b/tests/SysadminsLV.PKI.Win.Tests/CertificateTemplates/CertificateTemplateTests.cs
@@ -14,7 +14,7 @@ namespace SysadminsLV.PKI.Win.Tests.CertificateTemplates;
 public class CertificateTemplateTests {
     [TestMethod]
     public void TestRegTemplates() {
-        foreach (CertificateTemplate template in CertificateTemplate.EnumTemplates()) {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
             Console.WriteLine(template.Name);
             CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameRegistry(template.Name);
             assertTemplate(template, refTemplate);
@@ -22,7 +22,7 @@ public class CertificateTemplateTests {
     }
     [TestMethod]
     public void TestDsTemplates() {
-        foreach (CertificateTemplate template in CertificateTemplate.EnumTemplates()) {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
             Console.WriteLine(template.Name);
             CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameDs(template.Name);
             assertTemplate(template, refTemplate);
@@ -30,7 +30,7 @@ public class CertificateTemplateTests {
     }
     [TestMethod]
     public void TestCertEnrollTemplates() {
-        var col = new CertificateTemplateCollection(CertificateTemplate.EnumTemplates());
+        CertificateTemplateCollection col = CertificateTemplateFactory.GetTemplatesDs();
         String serializedString = col.Export(CertificateTemplateExportFormat.XCep);
         var policy = new CX509EnrollmentPolicyWebServiceClass();
         policy.InitializeImport(Encoding.UTF8.GetBytes(serializedString));
@@ -130,7 +130,7 @@ public class CertificateTemplateTests {
     [TestMethod]
     public void TestRegExportImport() {
         var col = new CertificateTemplateCollection();
-        foreach (CertificateTemplate template in CertificateTemplate.EnumTemplates()) {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
             Console.WriteLine(template.Name);
             CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameRegistry(template.Name);
             col.Add(refTemplate);
@@ -150,7 +150,7 @@ public class CertificateTemplateTests {
     [TestMethod]
     public void TestDsExportImport() {
         var col = new CertificateTemplateCollection();
-        foreach (CertificateTemplate template in CertificateTemplate.EnumTemplates()) {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
             Console.WriteLine(template.Name);
             CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameDs(template.Name);
             col.Add(refTemplate);

--- a/tests/SysadminsLV.PKI.Win.Tests/CertificateTemplates/CertificateTemplateTests.cs
+++ b/tests/SysadminsLV.PKI.Win.Tests/CertificateTemplates/CertificateTemplateTests.cs
@@ -167,4 +167,33 @@ public class CertificateTemplateTests {
             assertTemplate(source, target);
         }
     }
+
+    [TestMethod]
+    public void TestDsTemplateAcl() {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
+            Console.WriteLine(template.Name);
+            var acl = template.GetSecurityDescriptor();
+            Assert.IsNotNull(acl);
+        }
+    }
+    [TestMethod]
+    public void TestRegTemplateAcl() {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
+            var regTemplate = CertificateTemplateFactory.CreateFromCommonNameRegistry(template.Name);
+            Console.WriteLine(template.Name);
+            var acl = regTemplate.GetSecurityDescriptor();
+            Assert.IsNotNull(acl);
+        }
+    }
+    [TestMethod]
+    public void TestCertEnrollTemplateAcl() {
+        String serializedString = CertificateTemplateFactory.GetTemplatesDs().Export(CertificateTemplateExportFormat.XCep);
+        var col = new CertificateTemplateCollection();
+        col.Import(serializedString, CertificateTemplateExportFormat.XCep);
+        foreach (CertificateTemplate template in col) {
+            Console.WriteLine(template.Name);
+            var acl = template.GetSecurityDescriptor();
+            Assert.IsNotNull(acl);
+        }
+    }
 }

--- a/tests/SysadminsLV.PKI.Win.Tests/CertificateTemplates/CertificateTemplateTests.cs
+++ b/tests/SysadminsLV.PKI.Win.Tests/CertificateTemplates/CertificateTemplateTests.cs
@@ -7,6 +7,7 @@ using Interop.CERTENROLLLib;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PKI.CertificateTemplates;
 using SysadminsLV.PKI.CertificateTemplates;
+using SysadminsLV.PKI.Security.AccessControl;
 using SysadminsLV.PKI.Utils;
 
 namespace SysadminsLV.PKI.Win.Tests.CertificateTemplates;
@@ -14,7 +15,7 @@ namespace SysadminsLV.PKI.Win.Tests.CertificateTemplates;
 public class CertificateTemplateTests {
     [TestMethod]
     public void TestRegTemplates() {
-        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesFromDs()) {
             Console.WriteLine(template.Name);
             CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameRegistry(template.Name);
             assertTemplate(template, refTemplate);
@@ -22,7 +23,7 @@ public class CertificateTemplateTests {
     }
     [TestMethod]
     public void TestDsTemplates() {
-        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesFromDs()) {
             Console.WriteLine(template.Name);
             CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameDs(template.Name);
             assertTemplate(template, refTemplate);
@@ -30,7 +31,7 @@ public class CertificateTemplateTests {
     }
     [TestMethod]
     public void TestCertEnrollTemplates() {
-        CertificateTemplateCollection col = CertificateTemplateFactory.GetTemplatesDs();
+        CertificateTemplateCollection col = CertificateTemplateFactory.GetTemplatesFromDs();
         String serializedString = col.Export(CertificateTemplateExportFormat.XCep);
         var policy = new CX509EnrollmentPolicyWebServiceClass();
         policy.InitializeImport(Encoding.UTF8.GetBytes(serializedString));
@@ -130,7 +131,7 @@ public class CertificateTemplateTests {
     [TestMethod]
     public void TestRegExportImport() {
         var col = new CertificateTemplateCollection();
-        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesFromDs()) {
             Console.WriteLine(template.Name);
             CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameRegistry(template.Name);
             col.Add(refTemplate);
@@ -150,7 +151,7 @@ public class CertificateTemplateTests {
     [TestMethod]
     public void TestDsExportImport() {
         var col = new CertificateTemplateCollection();
-        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesFromDs()) {
             Console.WriteLine(template.Name);
             CertificateTemplate refTemplate = CertificateTemplateFactory.CreateFromCommonNameDs(template.Name);
             col.Add(refTemplate);
@@ -170,29 +171,28 @@ public class CertificateTemplateTests {
 
     [TestMethod]
     public void TestDsTemplateAcl() {
-        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesFromDs()) {
             Console.WriteLine(template.Name);
-            var acl = template.GetSecurityDescriptor();
+            CertTemplateSecurityDescriptor acl = template.GetSecurityDescriptor();
             Assert.IsNotNull(acl);
         }
     }
     [TestMethod]
     public void TestRegTemplateAcl() {
-        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesDs()) {
-            var regTemplate = CertificateTemplateFactory.CreateFromCommonNameRegistry(template.Name);
+        foreach (CertificateTemplate template in CertificateTemplateFactory.GetTemplatesFromRegistry()) {
             Console.WriteLine(template.Name);
-            var acl = regTemplate.GetSecurityDescriptor();
+            CertTemplateSecurityDescriptor acl = template.GetSecurityDescriptor();
             Assert.IsNotNull(acl);
         }
     }
     [TestMethod]
     public void TestCertEnrollTemplateAcl() {
-        String serializedString = CertificateTemplateFactory.GetTemplatesDs().Export(CertificateTemplateExportFormat.XCep);
+        String serializedString = CertificateTemplateFactory.GetTemplatesFromDs().Export(CertificateTemplateExportFormat.XCep);
         var col = new CertificateTemplateCollection();
         col.Import(serializedString, CertificateTemplateExportFormat.XCep);
         foreach (CertificateTemplate template in col) {
             Console.WriteLine(template.Name);
-            var acl = template.GetSecurityDescriptor();
+            CertTemplateSecurityDescriptor acl = template.GetSecurityDescriptor();
             Assert.IsNotNull(acl);
         }
     }


### PR DESCRIPTION
Implemented `SysadminsLV.PKI.CertificateTemplates.CertificateTemplateFactory` class and obsoleted:
- `PKI.CertificateTemplates.CertificateTemplate.EnumTemplates`
- `PKI.CertificateTemplates.CertificateTemplate.FromCommonName`
- `PKI.CertificateTemplates.CertificateTemplate.FromDisplayName`
- `PKI.CertificateTemplates.CertificateTemplate.FromOid`

changed:
- `SysadminsLV.PKI.Management.ActiveDirectory.DsCertTemplateContainer.CertificateTemplates` now returns `SysadminsLV.PKI.CertificateTemplates.CertificateTemplateCollection` instead of old plain array. In addition, this property is no longer automatic, it is getter only. This means that it doesn't reflect changes in certificate templates after class is instantiated.